### PR TITLE
讓擲骰開關功能的實際行爲符合文檔説明

### DIFF
--- a/modules/core-analytics.js
+++ b/modules/core-analytics.js
@@ -322,7 +322,7 @@ async function z_stop(mainMsg, groupid) {
 	}
 	let groupInfo = exports.z_stop.initialize().save.find(e => e.groupid == groupid)
 	if (!groupInfo || !groupInfo.blockfunction) return;
-	let match = groupInfo.blockfunction.find(e => e.toLowerCase() == mainMsg[0].toLowerCase())
+	let match = groupInfo.blockfunction.find(e => mainMsg[0].toLowerCase().includes(e.toLowerCase()))
 	if (match) {
 		(debugMode) ? console.log('Match AND STOP') : '';
 		return true;


### PR DESCRIPTION
`.bk`指令的幫助文檔中闡述的行爲是當指令“包含”關鍵字便不會發動，然而實際行爲是對在第一個空格前的字符做完整比對。此PR將機制改成當第一個空格前的字符包含禁用字則不發動，使實際行爲與文檔説明相符。

文檔中的例子：
https://github.com/hktrpg/TG.line.Discord.Roll.Bot/blob/992598ae7bf9d43b75f72eabbd338f5ed57f5f80/roll/z_stop.js#L29
實際執行結果：
![image](https://user-images.githubusercontent.com/37703689/142452841-cb22c4a7-af83-4ef6-8ef6-892d23b13f3e.png)

---
There's an inconsistency between what's described in the documentation vs the actual implementation. The documentation illustrates that when a command *contains* any character in blacklist then it won't fire. In actual implementation however, the bot only checks if the first word of the message exactly matches a blasklist word. This PR fixes it by changing the match mechanism from an absolute equality check to a `string.includes()` check.