### PR TITLE
Fix discord awake

### DIFF
--- a/modules/core-Discord.js
+++ b/modules/core-Discord.js
@@ -43,7 +43,7 @@ async function gracefulShutdown() {
         
         // Destroy all clusters
         console.log('[Cluster] Destroying all clusters...');
-        await manager.destroy();
+        await manager.kill();
         
         console.log('[Cluster] Graceful shutdown completed');
         process.exit(0);

--- a/modules/core-Discord.js
+++ b/modules/core-Discord.js
@@ -34,7 +34,11 @@ async function gracefulShutdown() {
         // Stop heartbeat manager
         if (manager.heartbeat) {
             console.log('[Cluster] Stopping heartbeat manager...');
-            manager.heartbeat.stop();
+            try {
+                manager.heartbeat.stop();
+            } catch (e) {
+                console.warn(`[Cluster] A non-critical error occurred while stopping the heartbeat manager: ${e.message}. Shutdown will continue.`);
+            }
         }
         
         // Destroy all clusters

--- a/modules/core-Discord.js
+++ b/modules/core-Discord.js
@@ -89,7 +89,7 @@ manager.on('clusterCreate', shard => {
         // Ensure all clusters have been created before checking if they are ready
         if (shard.manager.clusters.size !== shard.manager.totalClusters) return;
 
-        const allReady = shard.manager.clusters.every(c => c.ready);
+        const allReady = Array.from(shard.manager.clusters.values()).every(c => c.ready);
 
         if (allReady) {
             heartbeatStarted = true;

--- a/modules/core-Discord.js
+++ b/modules/core-Discord.js
@@ -36,8 +36,8 @@ async function gracefulShutdown() {
             console.log('[Cluster] Stopping heartbeat manager...');
             try {
                 manager.heartbeat.stop();
-            } catch (e) {
-                console.warn(`[Cluster] A non-critical error occurred while stopping the heartbeat manager: ${e.message}. Shutdown will continue.`);
+            } catch (error) {
+                console.warn(`[Cluster] A non-critical error occurred while stopping the heartbeat manager: ${error.message}. Shutdown will continue.`);
             }
         }
         
@@ -89,7 +89,7 @@ manager.on('clusterCreate', shard => {
         // Ensure all clusters have been created before checking if they are ready
         if (shard.manager.clusters.size !== shard.manager.totalClusters) return;
 
-        const allReady = Array.from(shard.manager.clusters.values()).every(c => c.ready);
+        const allReady = [...shard.manager.clusters.values()].every(c => c.ready);
 
         if (allReady) {
             heartbeatStarted = true;

--- a/modules/discord_bot.js
+++ b/modules/discord_bot.js
@@ -165,12 +165,18 @@ client.once('ready', async () => {
 	const HEARTBEAT_CHECK_INTERVAL = 1000 * 60;
 	const WARNING_THRESHOLD = 3;
 	const CRITICAL_THRESHOLD = 5;
+	const GRACE_PERIOD = (Number(process.env.DISCORD_STARTUP_GRACE_PERIOD) || 6) * 60 * 1000;
 	const restartServer = () => {
 		require('child_process').exec('sudo reboot');
 	}
 	let heartbeat = 0;
 	console.log('Discord Heartbeat: Ready...')
 	setInterval(async () => {
+		if (Date.now() - client.readyTimestamp < GRACE_PERIOD) {
+			console.log('Discord Heartbeat: In startup grace period...');
+			heartbeat = 0;
+			return;
+		}
 		const isAwake = await checkWakeUp();
 		if (isAwake === true) {
 			heartbeat = 0;

--- a/modules/discord_bot.js
+++ b/modules/discord_bot.js
@@ -162,21 +162,47 @@ client.once('ready', async () => {
 	let switchSetActivity = 0;
 
 	//await sleep(6);
+	// eslint-disable-next-line no-unused-vars
+	const refreshId2 = setInterval(async () => {
+		switch (switchSetActivity % 2) {
+			case 1:
+				client.user.setActivity(`${candle.checker() || '🌼'}bothelp | hktrpg.com🍎`);
+				break;
+			default:
+				client.user.setActivity(await count2());
+				break;
+		}
+		switchSetActivity = (switchSetActivity % 2) ? 2 : 3;
+	}, 180_000);
+});
+
+
+let heartbeatInterval = null;
+client.cluster.on('message', message => {
+	if (message?.type === 'startHeartbeat') {
+		if (client.cluster.id === 0) {
+			console.log('[Cluster 0] Received startHeartbeat signal. Starting heartbeat monitor.');
+			startHeartbeatMonitor();
+		}
+	}
+});
+
+function startHeartbeatMonitor() {
+	if (heartbeatInterval) {
+		clearInterval(heartbeatInterval);
+	}
+
 	const HEARTBEAT_CHECK_INTERVAL = 1000 * 60;
 	const WARNING_THRESHOLD = 3;
 	const CRITICAL_THRESHOLD = 5;
-	const GRACE_PERIOD = (Number(process.env.DISCORD_STARTUP_GRACE_PERIOD) || 6) * 60 * 1000;
 	const restartServer = () => {
 		require('child_process').exec('sudo reboot');
 	}
 	let heartbeat = 0;
-	console.log('Discord Heartbeat: Ready...')
-	setInterval(async () => {
-		if (Date.now() - client.readyTimestamp < GRACE_PERIOD) {
-			console.log('Discord Heartbeat: In startup grace period...');
-			heartbeat = 0;
-			return;
-		}
+	
+	console.log('Discord Heartbeat Monitor Started on Cluster 0.');
+
+	heartbeatInterval = setInterval(async () => {
 		const isAwake = await checkWakeUp();
 		if (isAwake === true) {
 			heartbeat = 0;
@@ -202,26 +228,11 @@ client.once('ready', async () => {
 			}
 		}
 
-
 		if (heartbeat > 20) {
 			restartServer();
 		}
-
 	}, HEARTBEAT_CHECK_INTERVAL);
-	// eslint-disable-next-line no-unused-vars
-	const refreshId2 = setInterval(async () => {
-		switch (switchSetActivity % 2) {
-			case 1:
-				client.user.setActivity(`${candle.checker() || '🌼'}bothelp | hktrpg.com🍎`);
-				break;
-			default:
-				client.user.setActivity(await count2());
-				break;
-		}
-		switchSetActivity = (switchSetActivity % 2) ? 2 : 3;
-	}, 180_000);
-});
-
+}
 
 async function replilyMessage(message, result) {
 	const displayname = (message.member && message.member.id) ? `<@${message.member.id}>${candle.checker(message.member.id)}\n` : '';


### PR DESCRIPTION
This pull request introduces improvements to the cluster management and heartbeat monitoring logic for the Discord bot. The main focus is on making the heartbeat monitor start only when all clusters are ready, ensuring it runs exclusively on cluster 0, and enhancing the shutdown process to handle errors gracefully. Additionally, some code refactoring was done for better clarity and maintainability.

**Cluster coordination and heartbeat monitoring:**

* Ensured the heartbeat monitor only starts after all clusters are ready, and only on cluster 0, by broadcasting a `startHeartbeat` message once readiness is confirmed and checking for it in each cluster (`modules/core-Discord.js`, `modules/discord_bot.js`). [[1]](diffhunk://#diff-9d6449782715bea0912642195a601f5db118af8083a12c95d7b9c8aa46f7b235R79-R98) [[2]](diffhunk://#diff-992db930d3d7c5f2f64b4f388504f0597101bd11ad84b5c0bc737716fd9f52f1R165-R205)
* Refactored the heartbeat monitor logic to use a named interval (`heartbeatInterval`) and moved its initialization into a dedicated function (`startHeartbeatMonitor`) for better control and cleanup.

**Graceful shutdown improvements:**

* Wrapped the heartbeat manager shutdown in a try/catch block to prevent non-critical errors from interrupting the shutdown process, logging warnings if needed (`modules/core-Discord.js`).
* Changed the cluster shutdown method from `manager.destroy()` to `manager.kill()` for more robust cluster termination (`modules/core-Discord.js`).

**Code cleanup:**

* Removed duplicate or misplaced interval setup for activity switching and improved code organization in `modules/discord_bot.js`.