### PR TITLE
Fix tarot label/image mismatch in daily draw

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "globals": "^16.3.0",
     "jest": "^28.1.2",
     "jest-junit": "^16.0.0",
+    "marked": "15",
     "mongodb-memory-server": "^11.0.1",
     "proxyquire": "^2.1.3",
     "yarn-audit-fix": "^9.3.10"

--- a/roll/1-funny.js
+++ b/roll/1-funny.js
@@ -1445,13 +1445,28 @@ function getTarotLabel(translate, index) {
 	return getFunnyIndexedText(translate, 'tarot_label', TarotList2, index);
 }
 
+// TarotList (image URLs) and TarotList2 / i18n labels use different card orders.
+// Look up image by canonical Chinese label so daily tarot text and image stay in sync.
+let tarotUrlByLabel = null;
+function getTarotUrlByLabel(canonicalLabel) {
+	if (!tarotUrlByLabel) {
+		tarotUrlByLabel = new Map();
+		for (const item of TarotList) {
+			const newlineIndex = item.indexOf('\n');
+			if (newlineIndex === -1) continue;
+			tarotUrlByLabel.set(item.slice(0, newlineIndex), item.slice(newlineIndex + 1));
+		}
+	}
+	return tarotUrlByLabel.get(canonicalLabel);
+}
+
 function getTarotCardLine(translate, index) {
 	const label = getTarotLabel(translate, index);
-	const raw = TarotList[index];
-	if (!raw || !raw.includes('\n')) {
+	const url = getTarotUrlByLabel(TarotList2[index]);
+	if (!url) {
 		return label;
 	}
-	return `${label}\n${raw.slice(raw.indexOf('\n') + 1)}`;
+	return `${label}\n${url}`;
 }
 
 function shuffleTarotIndices(length) {
@@ -1464,8 +1479,7 @@ function shuffleTarotIndices(length) {
 }
 
 function pickShuffledTarotCards(translate, count, withUrl = false) {
-	const length = withUrl ? TarotList.length : TarotList2.length;
-	const indices = shuffleTarotIndices(length);
+	const indices = shuffleTarotIndices(TarotList2.length);
 	return indices.slice(0, count).map((index) => (withUrl ? getTarotCardLine(translate, index) : getTarotLabel(translate, index)));
 }
 

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -10,8 +10,6 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-// Installed only for Pages CI (see .github/workflows/pages.yml), not a runtime dependency
-// eslint-disable-next-line n/no-extraneous-require
 const { marked } = require('marked');
 
 const repoRoot = path.join(__dirname, '..');

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -10,6 +10,8 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+// Installed only for Pages CI (see .github/workflows/pages.yml), not a runtime dependency
+// eslint-disable-next-line n/no-extraneous-require
 const { marked } = require('marked');
 
 const repoRoot = path.join(__dirname, '..');
@@ -80,7 +82,7 @@ function loadHeaderHtml(pageTitle) {
 	// Locale switcher needs /api/www-i18n (not available on GitHub Pages)
 	header = header.replaceAll(/<li class="nav-item dropdown" id="www-locale-switcher">[\s\S]*?<\/li>/g, '');
 	if (pageTitle) {
-		header = header.replaceAll(/<span id="title"><\/span>/g, `<span id="title">${pageTitle}</span>`);
+		header = header.replaceAll('<span id="title"></span>', `<span id="title">${pageTitle}</span>`);
 	}
 	return header;
 }
@@ -97,7 +99,7 @@ function injectSiteHeader(fileName, pageTitle) {
 		console.warn(`${fileName} has no #header placeholder; skip inject`);
 		return;
 	}
-	html = html.replaceAll(/<div id="header"><\/div>/g, header);
+	html = html.replaceAll('<div id="header"></div>', header);
 	fs.writeFileSync(filePath, html, 'utf8');
 	console.log(`injected header into ${fileName}`);
 }

--- a/test/funny.test.js
+++ b/test/funny.test.js
@@ -100,6 +100,46 @@ describe('Funny Module Tests', () => {
         expect(result.quotes).toBe(true);
     });
 
+    // Regression: TarotList (image URLs) and TarotList2/i18n labels used different card orders,
+    // so e.g. 寶劍八 text could show CUPS_QUEEN.jpg. Label and filename must stay aligned.
+    test('Daily tarot card label matches image filename', async () => {
+        const suitPrefix = [
+            ['寶劍', 'SWORDS'],
+            ['聖杯', 'CUPS'],
+            ['錢幣', 'PANTA'],
+            ['權杖', 'WANDS']
+        ];
+        const mismatches = [];
+
+        for (let i = 0; i < 120; i++) {
+            const result = await funny.rollDiceCommand({
+                inputStr: '每日塔羅',
+                mainMsg: ['每日塔羅'],
+                displayname: 'testUser'
+            });
+            const match = result.text.match(/\n([^\n]+)\n(https:\/\/\S+\/assets\/tarot\/(\S+))/);
+            if (!match) {
+                if (result.text.includes('空白')) continue;
+                mismatches.push(`missing image URL: ${result.text}`);
+                continue;
+            }
+            const [, label, , file] = match;
+            for (const [namePrefix, filePrefix] of suitPrefix) {
+                if (label.startsWith(namePrefix) && !file.startsWith(filePrefix)) {
+                    mismatches.push(`${label} -> ${file}`);
+                }
+            }
+            if (label.includes('－') && !file.includes('-Re')) {
+                mismatches.push(`reversed label without -Re: ${label} -> ${file}`);
+            }
+            if (label.includes('＋') && file.includes('-Re')) {
+                mismatches.push(`upright label with -Re: ${label} -> ${file}`);
+            }
+        }
+
+        expect(mismatches).toEqual([]);
+    });
+
     test('Test rollDiceCommand with 時間塔羅', async () => {
         const result = await funny.rollDiceCommand({
             inputStr: '時間塔羅',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6712,6 +6712,11 @@ mammoth@^1.11.0:
     underscore "^1.13.1"
     xmlbuilder "^10.0.0"
 
+marked@15:
+  version "15.0.12"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-15.0.12.tgz#30722c7346e12d0a2d0207ab9b0c4f0102d86c4e"
+  integrity sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==
+
 math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"


### PR DESCRIPTION
Map tarot image URLs by canonical card label instead of index so localized daily tarot labels always pair with the correct image, and use TarotList2 length consistently when shuffling picks. Adds a regression test that repeatedly checks suit and reversed/upright filename alignment, and updates the Pages build script with safer literal `replaceAll` usage plus a lint-safe `marked` import comment.