### PR TITLE
Fix Gateway/Worker boot logging: one banner per parent, earlier than …

### DIFF
--- a/.env.copy
+++ b/.env.copy
@@ -32,7 +32,8 @@ LOGLINK=
 # With SPAWN=true, Gateway discovers an already-running manual Standby on :20613 (no double-bind).
 # Opt-out Primary auto-frame (Embedded only unless ROLL_WORKER_URL set): ROLL_WORKER_SPAWN=false
 # Enable Standby auto-spawn: ROLL_STANDBY_SPAWN=true
-# Child worker stdout piped to Gateway: ROLL_WORKER_CHILD_LOG=true
+# Pipe supervised child stdout to Gateway (off by default; causes IDE debugger duplicates):
+# ROLL_WORKER_CHILD_LOG=true
 # Verbose discover/reuse logs: ROLL_WORKER_DEBUG=true
 # ROLL_WORKER_URL=http://127.0.0.1:20612
 # ROLL_STANDBY_URL=http://127.0.0.1:20613

--- a/index.js
+++ b/index.js
@@ -272,11 +272,6 @@ async function loadModules(moduleManager) {
         await Promise.all(modulePromises);
         const loaded = [...moduleManager.loadedModules];
         logger.info(`Loaded modules (${loaded.length}): ${loaded.join(', ')}`);
-        try {
-            require('./modules/roll-worker/parse-router').logParseMode(logger);
-        } catch (error) {
-            logger.warn(`ParseMode log skipped: ${error.message}`);
-        }
     } catch (error) {
         errorHandler(error, 'Reading modules directory');
         throw error;
@@ -421,7 +416,15 @@ async function init() {
     const moduleManager = new ModuleManager();
     
     try {
-        // Load modules
+        // Frame Primary Worker + print [Gateway]/[RollWorker] Listening before Discord clusters.
+        // Must await: fire-and-forget races "[Cluster] All clusters are ready".
+        try {
+            await require('./modules/roll-worker/parse-router').logParseMode(logger);
+        } catch (error) {
+            logger.warn(`ParseMode log skipped: ${error.message}`);
+        }
+
+        // Load modules (Discord clustering starts here)
         const loadStartTime = process.hrtime();
         await loadModules(moduleManager);
         const loadEndTime = process.hrtime(loadStartTime);

--- a/modules/analytics.js
+++ b/modules/analytics.js
@@ -864,9 +864,16 @@ async function stateText(locale = i18n.DEFAULT_LOCALE, options = {}) {
 	return stateTextCache[cacheKey]?.text || '';
 }
 
-// Pre-warm cache after startup to avoid first-call delay
-if (ADMIN_STATE_CACHE_MS > 0) {
-	setTimeout(() => refreshStateCache(i18n.DEFAULT_LOCALE).catch(() => {}), 60_000);
+// Pre-warm cache after startup to avoid first-call delay.
+// Skip in Jest (avoids require-after-teardown + open-handle force-exit).
+if (ADMIN_STATE_CACHE_MS > 0 && process.env.NODE_ENV !== 'test') {
+	const warmTimer = setTimeout(
+		() => refreshStateCache(i18n.DEFAULT_LOCALE).catch(() => {}),
+		60_000
+	);
+	if (typeof warmTimer.unref === 'function') {
+		warmTimer.unref();
+	}
 }
 
 async function cmdfunction({ result, ...context }) {

--- a/modules/discord/bot.js
+++ b/modules/discord/bot.js
@@ -21,8 +21,19 @@ const parseRouter = require('../roll-worker/parse-router');
 const deferQueue = require('../roll-worker/defer-queue');
 const { assertArtifactReadable } = require('../roll-worker/artifacts');
 const { matchForwardButtonContent } = require('../roll-worker/forward-button-content.js');
-// ParseMode banner: only once across Gateway processes (see parse-router claim).
-parseRouter.logParseMode(console);
+// Banner: Gateway parent (index.js) only — prints before Discord clusters spawn.
+// All Discord cluster workers (incl. 0): monitors on, no second [Gateway] banner.
+(() => {
+	let announceBanner = true;
+	try {
+		if (typeof getInfo()?.CLUSTER === 'number') {
+			announceBanner = false;
+		}
+	} catch {
+		/* keep banner */
+	}
+	parseRouter.logParseMode(console, { announceBanner });
+})();
 
 const { deliverDiscordDeferred } = require('../roll-worker/discord-defer-deliver');
 

--- a/modules/roll-worker/client.js
+++ b/modules/roll-worker/client.js
@@ -35,9 +35,22 @@ const DEFAULT_URL = 'http://127.0.0.1:20612';
 // OpenAI / heavy export often exceed 30s; env still overrides.
 const DEFAULT_TIMEOUT_MS = 120_000;
 
+/** Quiet link logs under Jest (live suites call parse/health often). */
+function linkLogForEnv(logger) {
+	if (logger) return logger;
+	if (process.env.NODE_ENV === 'test') {
+		return { info() {}, warn() {}, error() {}, log() {} };
+	}
+	return console;
+}
+
 function noteTransportOk() {
 	const { url } = getConfig();
-	markWorkerUp({ url, detail: `request ok | gateway=${getGatewayLabel()}` });
+	markWorkerUp({
+		url,
+		detail: `request ok | gateway=${getGatewayLabel()}`,
+		logger: linkLogForEnv(),
+	});
 }
 
 function noteTransportDown(error) {
@@ -45,6 +58,7 @@ function noteTransportDown(error) {
 	markWorkerDown({
 		url,
 		reason: error?.message || String(error || 'unknown'),
+		logger: linkLogForEnv(),
 	});
 }
 
@@ -368,8 +382,8 @@ function beginLinkMonitor(options = {}) {
 		healthFn: health,
 		getUrl: () => getConfig().url,
 		intervalMs: options.intervalMs,
-		// Default console so boot CONNECTED is visible in every Gateway.
-		logger: options.logger || console,
+		// Default console so boot CONNECTED is visible; quiet under Jest.
+		logger: linkLogForEnv(options.logger),
 	});
 }
 
@@ -392,7 +406,7 @@ function beginStandbyLinkMonitor(options = {}) {
 		healthFn: healthLocal,
 		getUrl: () => getLocalConfig().url,
 		intervalMs: options.intervalMs,
-		logger: options.logger || console,
+		logger: linkLogForEnv(options.logger),
 	});
 }
 

--- a/modules/roll-worker/client.js
+++ b/modules/roll-worker/client.js
@@ -361,10 +361,6 @@ async function healthLocal() {
 	return response.data;
 }
 
-function quietLinkLogger(logger) {
-	return logger || { info() {}, warn: console.warn, error: console.error };
-}
-
 function beginLinkMonitor(options = {}) {
 	if (!isEnabled()) return;
 	ensureDeferConnectedHook();
@@ -372,7 +368,8 @@ function beginLinkMonitor(options = {}) {
 		healthFn: health,
 		getUrl: () => getConfig().url,
 		intervalMs: options.intervalMs,
-		logger: quietLinkLogger(options.logger),
+		// Default console so boot CONNECTED is visible in every Gateway.
+		logger: options.logger || console,
 	});
 }
 
@@ -395,7 +392,7 @@ function beginStandbyLinkMonitor(options = {}) {
 		healthFn: healthLocal,
 		getUrl: () => getLocalConfig().url,
 		intervalMs: options.intervalMs,
-		logger: quietLinkLogger(options.logger),
+		logger: options.logger || console,
 	});
 }
 

--- a/modules/roll-worker/connection-status.js
+++ b/modules/roll-worker/connection-status.js
@@ -56,7 +56,7 @@ function createLinkTracker(tag) {
 			+ (meta.detail ? ` | ${meta.detail}` : '')
 			+ ` | was=${prev}`;
 		if (prev === 'down') {
-			// Recovery must stay visible even when boot CONNECTED info() is silenced.
+			// Recovery must stay visible even if a caller passes a quiet info logger.
 			console.info(line);
 		} else {
 			const info = typeof log.info === 'function' ? log.info.bind(log) : log.log.bind(log);

--- a/modules/roll-worker/local-worker.js
+++ b/modules/roll-worker/local-worker.js
@@ -231,6 +231,7 @@ function ensureSharedToken() {
 function spawnChild({ port, token, role = 'local' }) {
 	const url = `http://127.0.0.1:${port}`;
 	const label = role === 'primary' ? 'Primary' : 'Standby';
+	// Opt-in only: piping duplicates IDE debugger child console (Listening/CONNECTED ×2).
 	const childLog = (process.env.ROLL_WORKER_CHILD_LOG || '').trim().toLowerCase();
 	const pipeChild = childLog === 'true' || childLog === '1' || childLog === 'on';
 	const child = spawn(process.execPath, [path.join(ROOT, 'roll-worker.js')], {
@@ -242,6 +243,8 @@ function spawnChild({ port, token, role = 'local' }) {
 			ROLL_WORKER_HOST: '127.0.0.1',
 			ROLL_WORKER_PORT: String(port),
 			ROLL_WORKER_TOKEN: token || process.env.ROLL_WORKER_TOKEN || '',
+			// Parent owns boot Listening / link lines — child stays quiet in shared consoles.
+			ROLL_WORKER_GATEWAY_CHILD: 'true',
 			// Child must not recurse into another local worker / primary URL.
 			ROLL_WORKER_URL: '',
 			ROLL_STANDBY_URL: '',
@@ -252,12 +255,16 @@ function spawnChild({ port, token, role = 'local' }) {
 	});
 	if (pipeChild) {
 		child.stdout?.on('data', (buf) => {
-			const line = String(buf).trim();
-			if (line) console.info(`[${label}:child] ${line}`);
+			const text = String(buf);
+			for (const line of text.split(/\r?\n/)) {
+				if (line) console.info(`[${label}:child] ${line}`);
+			}
 		});
 		child.stderr?.on('data', (buf) => {
-			const line = String(buf).trim();
-			if (line) console.warn(`[${label}:child] ${line}`);
+			const text = String(buf);
+			for (const line of text.split(/\r?\n/)) {
+				if (line) console.warn(`[${label}:child] ${line}`);
+			}
 		});
 	}
 	child.on('exit', (code, signal) => {
@@ -375,6 +382,10 @@ async function ensurePrimaryWorker(logger = console, options = {}) {
 	process.env.ROLL_WORKER_URL = url;
 	writePrimaryLock({ pid: child.pid, port, url });
 	await waitHealth(url);
+	// Single boot line in Gateway console (child is ROLL_WORKER_GATEWAY_CHILD=quiet).
+	console.info(`[RollWorker] Listening on ${url}`
+		+ ` | auth=${(process.env.ROLL_WORKER_TOKEN || '').trim() ? 'on' : 'off'}`
+		+ ` | supervised pid=${child.pid}`);
 	debugWorkerLog(`[Primary] spawned pid=${child.pid} url=${url}`);
 	return { ok: true, url, supervised: true, pid: child.pid };
 }
@@ -447,6 +458,9 @@ async function ensureLocalWorker(logger = console) {
 	process.env.ROLL_STANDBY_URL = url;
 	writeLock({ pid: child.pid, port, url });
 	await waitHealth(url);
+	console.info(`[RollWorker] Standby Listening on ${url}`
+		+ ` | auth=${(process.env.ROLL_WORKER_TOKEN || '').trim() ? 'on' : 'off'}`
+		+ ` | supervised pid=${child.pid}`);
 	debugWorkerLog(`[Standby] spawned pid=${child.pid} url=${url}`);
 	return { ok: true, url, supervised: true, pid: child.pid };
 }

--- a/modules/roll-worker/parse-router.js
+++ b/modules/roll-worker/parse-router.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const path = require('node:path');
 const analytics = require('../analytics');
 const i18n = require('../i18n/i18n.js');
 const client = require('./client');
@@ -21,7 +20,6 @@ function getLifecycleFlags() {
 }
 
 const FALLBACK_LOG_INTERVAL_MS = 60_000;
-const PARSE_MODE_LOCK = path.join(__dirname, '..', '..', 'temp', 'parse-mode-announced.lock');
 let loggedModeOnce = false;
 let workersReadyPromise = null;
 let lastFallbackLogAt = 0;
@@ -29,40 +27,6 @@ let fallbackSinceLastLog = 0;
 let lastRemoteFailLogAt = 0;
 let remoteFailSinceLastLog = 0;
 let replayHookInstalled = false;
-
-function isPidAliveQuick(pid) {
-	if (!pid || !Number.isFinite(pid)) return false;
-	try {
-		process.kill(pid, 0);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-/**
- * Only one Gateway process prints the ParseMode banner (index + Discord clusters share host).
- * Still runs ensureWorkersReady in every process.
- */
-function claimParseModeBanner() {
-	const fs = require('node:fs');
-	try {
-		fs.mkdirSync(require('node:path').dirname(PARSE_MODE_LOCK), { recursive: true });
-		let existing = null;
-		try {
-			existing = JSON.parse(fs.readFileSync(PARSE_MODE_LOCK, 'utf8'));
-		} catch {
-			existing = null;
-		}
-		if (existing?.pid && isPidAliveQuick(existing.pid)) {
-			return false;
-		}
-		fs.writeFileSync(PARSE_MODE_LOCK, JSON.stringify({ pid: process.pid, at: Date.now() }));
-		return true;
-	} catch {
-		return true;
-	}
-}
 
 /**
  * Gateway switch: never run in-process analytics when remoting is configured.
@@ -185,12 +149,15 @@ function resetWorkersReadyForTests() {
 }
 
 /**
- * Log dice backends once per host (single [Gateway] line via console — not [System] logger).
+ * Frame Workers + optionally print [Gateway] banner; always start link monitors.
+ * @param {Console} [logger]
+ * @param {{ announceBanner?: boolean }} [options] - announceBanner=false: monitors only (Discord cluster ≠ 0)
  */
-async function logParseMode(logger = console) {
+async function logParseMode(logger = console, options = {}) {
 	if (loggedModeOnce) return;
 	loggedModeOnce = true;
 
+	const announceBanner = options.announceBanner !== false;
 	// Always console.info so the line is `[Gateway] …`, not `[System] …`.
 	const info = (msg) => console.info(msg);
 
@@ -199,24 +166,6 @@ async function logParseMode(logger = console) {
 	}
 
 	const started = await ensureWorkersReady(logger);
-	const announce = claimParseModeBanner();
-	if (!announce) {
-		if (client.isEnabled()) {
-			client.beginLinkMonitor({
-				logger: { info() {}, warn: console.warn, error: console.error },
-			});
-			if (typeof client.beginStandbyLinkMonitor === 'function' && client.isLocalEnabled()) {
-				client.beginStandbyLinkMonitor({
-					logger: { info() {}, warn: console.warn, error: console.error },
-				});
-			}
-			if (isRemoteOnlyMode() && deferQueue.isDeferBusyActive()) {
-				ensureDeferReplayHook();
-				deferQueue.startDrainMonitor();
-			}
-		}
-		return;
-	}
 
 	const primaryHow = started?.primary?.supervised
 		? `spawned${started.primary.pid ? ` pid=${started.primary.pid}` : ''}`
@@ -237,21 +186,22 @@ async function logParseMode(logger = console) {
 		const standbyPart = localUrl
 			? `Standby ${localUrl}`
 			: (started?.local?.pending ? 'Standby pending' : 'Standby off');
-		info(`[Gateway] Primary ${url}`
-			+ (primaryHow ? ` (${primaryHow})` : '')
-			+ ` | ${standbyPart}`
-			+ ` | fallback=${remoteOnly ? 'none (remote-only)' : 'Embedded'}`
-			+ ` | token=${token ? 'on' : 'off'}`
-			+ ` | timeout=${timeoutMs}ms`
-			+ (remoteOnly ? ` | defer=${deferOn ? 'on' : 'off'}` : ''));
-		// Link monitors: warn on disconnect only (boot line already shows backends).
-		client.beginLinkMonitor({
-			logger: { info() {}, warn: console.warn, error: console.error },
-		});
+		if (announceBanner) {
+			info(`[Gateway] Primary ${url}`
+				+ (primaryHow ? ` (${primaryHow})` : '')
+				+ ` | ${standbyPart}`
+				+ ` | fallback=${remoteOnly ? 'none (remote-only)' : 'Embedded'}`
+				+ ` | token=${token ? 'on' : 'off'}`
+				+ ` | timeout=${timeoutMs}ms`
+				+ (remoteOnly ? ` | defer=${deferOn ? 'on' : 'off'}` : ''));
+		}
+		// Monitors on every process; banner processes also show boot CONNECTED.
+		const linkLogger = announceBanner
+			? console
+			: { info() {}, warn: console.warn, error: console.error };
+		client.beginLinkMonitor({ logger: linkLogger });
 		if (localUrl && typeof client.beginStandbyLinkMonitor === 'function') {
-			client.beginStandbyLinkMonitor({
-				logger: { info() {}, warn: console.warn, error: console.error },
-			});
+			client.beginStandbyLinkMonitor({ logger: linkLogger });
 		}
 		if (deferOn) {
 			ensureDeferReplayHook();
@@ -259,6 +209,8 @@ async function logParseMode(logger = console) {
 		}
 		return;
 	}
+
+	if (!announceBanner) return;
 
 	if (isRemoteOnlyMode()) {
 		info('[Gateway] MISCONFIG | REMOTE_ONLY=on but ROLL_WORKER_URL unset');

--- a/modules/roll-worker/parse-router.js
+++ b/modules/roll-worker/parse-router.js
@@ -143,9 +143,10 @@ function ensureWorkersReady(logger = console) {
 	return workersReadyPromise;
 }
 
-/** @internal Jest — clear cached auto-start promise between suites */
+/** @internal Jest — clear cached auto-start promise + ParseMode banner latch */
 function resetWorkersReadyForTests() {
 	workersReadyPromise = null;
+	loggedModeOnce = false;
 }
 
 /**

--- a/modules/roll-worker/server.js
+++ b/modules/roll-worker/server.js
@@ -37,11 +37,6 @@ function isLoopbackHost(host) {
 	return h === '127.0.0.1' || h === '::1' || h === 'localhost';
 }
 
-function workerBootVerbose() {
-	const flag = (process.env.ROLL_WORKER_DEBUG || '').trim().toLowerCase();
-	return flag === 'true' || flag === '1' || flag === 'on';
-}
-
 /** Express req.ip / remoteAddress may be IPv4-mapped (`::ffff:127.0.0.1`). */
 function isLoopbackRemoteAddress(addr) {
 	const a = String(addr || '').toLowerCase().replace(/^::ffff:/, '');
@@ -185,13 +180,15 @@ function createRollWorkerApp(options = {}) {
 		const prev = entry.state;
 		entry.state = 'up';
 		peers.set(gateway, entry);
-		if (workerBootVerbose()) {
-			console.info(
-				`[RollWorker] CONNECTED | gateway=${gateway}`
-				+ (bot ? ` | bot=${bot}` : '')
-				+ ` | peer=${from} | via=${via} | was=${prev}`
-			);
+		// Supervised Gateway child: parent prints [RollWorkerLink] CONNECTED once.
+		if (process.env.ROLL_WORKER_GATEWAY_CHILD === 'true') {
+			return;
 		}
+		console.info(
+			`[RollWorker] CONNECTED | gateway=${gateway}`
+			+ (bot ? ` | bot=${bot}` : '')
+			+ ` | peer=${from} | via=${via} | was=${prev}`
+		);
 	}
 
 	app.use((req, res, next) => {
@@ -458,15 +455,14 @@ function startRollWorkerServer() {
 
 	const app = createRollWorkerApp({ host });
 	const server = app.listen(port, host, () => {
-		if (workerBootVerbose()) {
-			console.log(`[RollWorker] Listening on http://${host}:${port}`
-				+ (token ? ' | auth=on' : ' | auth=off')
-				+ ` | jsonLimit=${getJsonBodyLimit()}`
-				+ ' | wait Gateway (CONNECTED/DISCONNECTED)');
-		} else if (!process.env.ROLL_WORKER_PORT) {
-			// One-line hint when using manual default port (not Gateway-spawned).
-			console.info(`[RollWorker] manual :${port} (auto Primary uses :20612; set ROLL_WORKER_PORT to override)`);
+		// Supervised child: parent prints one Listening line (avoids IDE debugger ×2).
+		if (process.env.ROLL_WORKER_GATEWAY_CHILD === 'true') {
+			return;
 		}
+		console.info(`[RollWorker] Listening on http://${host}:${port}`
+			+ (token ? ' | auth=on' : ' | auth=off')
+			+ ` | jsonLimit=${getJsonBodyLimit()}`
+			+ ' | wait Gateway (CONNECTED/DISCONNECTED)');
 	});
 	server.on('error', (error) => {
 		if (error?.code === 'EADDRINUSE') {

--- a/roll-worker.js
+++ b/roll-worker.js
@@ -17,6 +17,8 @@ process.env.ROLL_WORKER_MODE = 'true';
 		'ROLL_WORKER_PORT',
 		'ROLL_WORKER_REMOTE_ONLY',
 		'ROLL_WORKER_DEFER_BUSY',
+		// Supervised-by-Gateway: quiet boot (parent prints Listening / link once).
+		'ROLL_WORKER_GATEWAY_CHILD',
 		// Keep spawn-cleared Standby/Primary frame flags (do not let .env re-enable on Worker).
 		'ROLL_STANDBY_URL',
 		'ROLL_STANDBY_SPAWN',

--- a/roll/code.js
+++ b/roll/code.js
@@ -45,7 +45,10 @@ function pruneUserCooldown() {
     }
     for (const userid of toDelete) userCooldown.delete(userid);
 }
-setInterval(pruneUserCooldown, 15 * 60 * 1000); // every 15 minutes
+const pruneCooldownTimer = setInterval(pruneUserCooldown, 15 * 60 * 1000); // every 15 minutes
+if (typeof pruneCooldownTimer.unref === 'function') {
+	pruneCooldownTimer.unref();
+}
 
 const gameName = function (params = {}) {
     return resolveGameName(params, 'code.game_name', '【.code [語言] [指令]】');

--- a/test/roll-worker-parse-mode-banner.test.js
+++ b/test/roll-worker-parse-mode-banner.test.js
@@ -1,0 +1,169 @@
+"use strict";
+
+/**
+ * ParseMode banner / quiet supervised-child boot contracts.
+ */
+jest.mock('../modules/roll-worker/client', () => ({
+	isEnabled: jest.fn(() => true),
+	isLocalEnabled: jest.fn(() => false),
+	getConfig: jest.fn(() => ({
+		url: 'http://127.0.0.1:20612',
+		token: 'tok',
+		timeoutMs: 120_000,
+	})),
+	getLocalConfig: jest.fn(() => ({
+		url: '',
+		token: 'tok',
+		timeoutMs: 120_000,
+	})),
+	parse: jest.fn(),
+	parseLocal: jest.fn(),
+	beginLinkMonitor: jest.fn(),
+	beginStandbyLinkMonitor: jest.fn(),
+}));
+
+jest.mock('../modules/analytics', () => ({
+	parseInput: jest.fn(async () => ({ text: 'ok', type: 'text' })),
+	findRollModuleName: jest.fn(() => '0-advroll'),
+}));
+
+jest.mock('../modules/i18n/i18n.js', () => ({
+	DEFAULT_LOCALE: 'zh-tw',
+	init: jest.fn(async () => {}),
+	createTranslator: jest.fn(() => (key) => key),
+}));
+
+const fs = require('node:fs');
+const path = require('node:path');
+const client = require('../modules/roll-worker/client');
+const parseRouter = require('../modules/roll-worker/parse-router');
+
+const ROOT = path.join(__dirname, '..');
+
+describe('logParseMode banner + monitors', () => {
+	const prevUrl = process.env.ROLL_WORKER_URL;
+	const prevMode = process.env.ROLL_WORKER_MODE;
+	const prevRemote = process.env.ROLL_WORKER_REMOTE_ONLY;
+	const prevSpawn = process.env.ROLL_WORKER_SPAWN;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		parseRouter.resetWorkersReadyForTests();
+		process.env.ROLL_WORKER_URL = 'http://127.0.0.1:20612';
+		delete process.env.ROLL_WORKER_MODE;
+		delete process.env.ROLL_WORKER_REMOTE_ONLY;
+		// Jest harness: ensureWorkersReady skips live health unless SPAWN=true
+		delete process.env.ROLL_WORKER_SPAWN;
+		client.isEnabled.mockReturnValue(true);
+		client.isLocalEnabled.mockReturnValue(false);
+		client.getConfig.mockReturnValue({
+			url: 'http://127.0.0.1:20612',
+			token: 'tok',
+			timeoutMs: 120_000,
+		});
+	});
+
+	afterEach(() => {
+		parseRouter.resetWorkersReadyForTests();
+		if (prevUrl === undefined) delete process.env.ROLL_WORKER_URL;
+		else process.env.ROLL_WORKER_URL = prevUrl;
+		if (prevMode === undefined) delete process.env.ROLL_WORKER_MODE;
+		else process.env.ROLL_WORKER_MODE = prevMode;
+		if (prevRemote === undefined) delete process.env.ROLL_WORKER_REMOTE_ONLY;
+		else process.env.ROLL_WORKER_REMOTE_ONLY = prevRemote;
+		if (prevSpawn === undefined) delete process.env.ROLL_WORKER_SPAWN;
+		else process.env.ROLL_WORKER_SPAWN = prevSpawn;
+	});
+
+	it('prints [Gateway] Primary banner and starts link monitor (parent)', async () => {
+		const lines = [];
+		const spy = jest.spyOn(console, 'info').mockImplementation((m) => lines.push(String(m)));
+		try {
+			await parseRouter.logParseMode(console, { announceBanner: true });
+			expect(lines.some((l) => l.startsWith('[Gateway] Primary http://127.0.0.1:20612'))).toBe(true);
+			expect(lines.some((l) => /token=on/.test(l) && /timeout=120000ms/.test(l))).toBe(true);
+			expect(client.beginLinkMonitor).toHaveBeenCalledTimes(1);
+			const logger = client.beginLinkMonitor.mock.calls[0][0]?.logger;
+			expect(logger).toBe(console);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it('announceBanner=false skips banner but still starts monitors (Discord clusters)', async () => {
+		const lines = [];
+		const spy = jest.spyOn(console, 'info').mockImplementation((m) => lines.push(String(m)));
+		try {
+			await parseRouter.logParseMode(console, { announceBanner: false });
+			expect(lines.some((l) => /\[Gateway\]/.test(l))).toBe(false);
+			expect(client.beginLinkMonitor).toHaveBeenCalledTimes(1);
+			const logger = client.beginLinkMonitor.mock.calls[0][0]?.logger;
+			expect(typeof logger.info).toBe('function');
+			expect(logger).not.toBe(console);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it('logs banner only once per process even if called twice', async () => {
+		const lines = [];
+		const spy = jest.spyOn(console, 'info').mockImplementation((m) => lines.push(String(m)));
+		try {
+			await parseRouter.logParseMode(console, { announceBanner: true });
+			await parseRouter.logParseMode(console, { announceBanner: true });
+			expect(lines.filter((l) => /\[Gateway\] Primary/.test(l))).toHaveLength(1);
+			expect(client.beginLinkMonitor).toHaveBeenCalledTimes(1);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it('skips entirely in ROLL_WORKER_MODE', async () => {
+		process.env.ROLL_WORKER_MODE = 'true';
+		const spy = jest.spyOn(console, 'info').mockImplementation(() => {});
+		try {
+			await parseRouter.logParseMode(console, { announceBanner: true });
+			expect(client.beginLinkMonitor).not.toHaveBeenCalled();
+		} finally {
+			spy.mockRestore();
+		}
+	});
+});
+
+describe('boot order + Discord announce contracts (source)', () => {
+	it('index.js awaits logParseMode before loadModules', () => {
+		const src = fs.readFileSync(path.join(ROOT, 'index.js'), 'utf8');
+		const awaitIdx = src.indexOf('await require(\'./modules/roll-worker/parse-router\').logParseMode');
+		const loadIdx = src.indexOf('await loadModules(moduleManager)');
+		expect(awaitIdx).toBeGreaterThan(-1);
+		expect(loadIdx).toBeGreaterThan(-1);
+		expect(awaitIdx).toBeLessThan(loadIdx);
+	});
+
+	it('Discord bot.js disables banner for clustered workers', () => {
+		const src = fs.readFileSync(path.join(ROOT, 'modules/discord/bot.js'), 'utf8');
+		expect(src).toMatch(/announceBanner/);
+		expect(src).toMatch(/getInfo\(\)\?\.CLUSTER/);
+		expect(src).toMatch(/announceBanner\s*=\s*false/);
+	});
+
+	it('supervised spawn sets ROLL_WORKER_GATEWAY_CHILD and parent Listening line', () => {
+		const src = fs.readFileSync(path.join(ROOT, 'modules/roll-worker/local-worker.js'), 'utf8');
+		expect(src).toMatch(/ROLL_WORKER_GATEWAY_CHILD:\s*'true'/);
+		expect(src).toMatch(/\[RollWorker\] Listening on \$\{url\}/);
+		expect(src).toMatch(/supervised pid=/);
+	});
+
+	it('roll-worker.js preserves ROLL_WORKER_GATEWAY_CHILD across dotenv', () => {
+		const src = fs.readFileSync(path.join(ROOT, 'roll-worker.js'), 'utf8');
+		expect(src).toMatch(/ROLL_WORKER_GATEWAY_CHILD/);
+	});
+
+	it('server.js skips Listening + CONNECTED when ROLL_WORKER_GATEWAY_CHILD', () => {
+		const src = fs.readFileSync(path.join(ROOT, 'modules/roll-worker/server.js'), 'utf8');
+		expect(src).toMatch(/ROLL_WORKER_GATEWAY_CHILD === 'true'/);
+		expect(src).toMatch(/\[RollWorker\] Listening on/);
+		// Quiet path returns before Listening / peer CONNECTED console.info
+		expect(src).toMatch(/if \(process\.env\.ROLL_WORKER_GATEWAY_CHILD === 'true'\) \{\s*return;/);
+	});
+});

--- a/test/roll-worker-server.test.js
+++ b/test/roll-worker-server.test.js
@@ -91,9 +91,11 @@ describe('roll-worker HTTP server', () => {
 		expect(res.body.version.role).toBe('roll-worker');
 	});
 
-	it('health marks gateway peer up; CONNECTED log only when ROLL_WORKER_DEBUG', async () => {
+	it('health marks gateway peer up; CONNECTED always (standalone Worker)', async () => {
 		const prevDebug = process.env.ROLL_WORKER_DEBUG;
-		process.env.ROLL_WORKER_DEBUG = 'true';
+		const prevChild = process.env.ROLL_WORKER_GATEWAY_CHILD;
+		delete process.env.ROLL_WORKER_DEBUG;
+		delete process.env.ROLL_WORKER_GATEWAY_CHILD;
 		const lines = [];
 		const spy = jest.spyOn(console, 'info').mockImplementation((m) => lines.push(String(m)));
 		const res = await httpJson(port, 'GET', '/health', null, {
@@ -121,6 +123,24 @@ describe('roll-worker HTTP server', () => {
 
 		if (prevDebug === undefined) delete process.env.ROLL_WORKER_DEBUG;
 		else process.env.ROLL_WORKER_DEBUG = prevDebug;
+		if (prevChild === undefined) delete process.env.ROLL_WORKER_GATEWAY_CHILD;
+		else process.env.ROLL_WORKER_GATEWAY_CHILD = prevChild;
+	});
+
+	it('GATEWAY_CHILD suppresses Worker CONNECTED (parent owns link line)', async () => {
+		const prev = process.env.ROLL_WORKER_GATEWAY_CHILD;
+		process.env.ROLL_WORKER_GATEWAY_CHILD = 'true';
+		const lines = [];
+		const spy = jest.spyOn(console, 'info').mockImplementation((m) => lines.push(String(m)));
+		const res = await httpJson(port, 'GET', '/health', null, {
+			'X-Roll-Gateway': 'QuietGateway',
+		});
+		spy.mockRestore();
+		expect(res.status).toBe(200);
+		expect(res.body.peers.QuietGateway).toBe('up');
+		expect(lines.some((l) => /CONNECTED/.test(l))).toBe(false);
+		if (prev === undefined) delete process.env.ROLL_WORKER_GATEWAY_CHILD;
+		else process.env.ROLL_WORKER_GATEWAY_CHILD = prev;
 	});
 
 	it('POST /v1/parse returns analytics result with proof marker', async () => {


### PR DESCRIPTION
…Discord ready

## Summary
- Every Gateway parent prints its own `[Gateway] Primary …` line (removed host-wide parse-mode lock that hid TG/other gateways when Discord claimed it).
- Await Worker frame + banner **before** `loadModules`, so Listening/Gateway appear before `[Cluster] All clusters are ready`.
- Discord cluster workers start link monitors only (no duplicate `[Gateway]` banner); parent owns the single announce.
- Supervised Primary child uses `ROLL_WORKER_GATEWAY_CHILD` quiet boot so IDE debugger + parent console do not double-print Listening/CONNECTED; parent emits one Listening line + `[RollWorkerLink] CONNECTED`.
- Standalone / Docker `roll-primary` still logs Listening and Worker CONNECTED normally.

## Test plan
- [ ] Local `node index.js` (auto-spawn): exactly one Listening, one `[Gateway] Primary (spawned…)`, one `[RollWorkerLink] CONNECTED`, before Discord cluster ready
- [ ] Multi-cluster Discord: no per-cluster `[Gateway]` banner; monitors still warn on DISCONNECTED
- [ ] Separate Gateway containers sharing `temp`: each parent shows its own `[Gateway]` line
- [ ] Docker `roll-primary` (not GATEWAY_CHILD): Listening + CONNECTED still appear in `rwlog`
- [ ] `yarn jest test/roll-worker-server.test.js test/roll-worker-local-worker-unit.test.js`