### PR TITLE
Enforce unique sparse index on accountPW.userName

### DIFF
--- a/modules/db/schema.js
+++ b/modules/db/schema.js
@@ -284,7 +284,8 @@ if (process.env.mongoURL) {
 
     models.accountPW = mongoose.model('accountPW', new Schema({
         id: { type: String, index: true },
-        userName: { type: String, index: true },
+        // Unique when set; sparse so registerChannel docs without login name stay allowed.
+        userName: { type: String, unique: true, sparse: true },
         password: String,
         legacyPassword: { type: String, default: null },
         channel: [{
@@ -297,6 +298,22 @@ if (process.env.mongoURL) {
             { 'channel.id': 1, 'channel.botname': 1 }
         ]
     }));
+
+    // Production has autoIndex off — ensure the sparse unique index exists at boot.
+    // Fails loudly if duplicate userName rows still exist (ops must clean them first).
+    models.accountPW.collection.createIndex(
+        { userName: 1 },
+        { unique: true, sparse: true, background: true, name: 'userName_1' }
+    ).catch((error) => {
+        console.error(
+            '[schema] accountPW.userName unique sparse index failed:'
+            + ` ${error?.message || error}`
+            + ' | find duplicates: db.accountpws.aggregate(['
+            + '{ $match: { userName: { $type: "string" } } },'
+            + '{ $group: { _id: "$userName", n: { $sum: 1 }, ids: { $push: "$id" } } },'
+            + '{ $match: { n: { $gt: 1 } } }])'
+        );
+    });
 
     models.allowRolling = mongoose.model('allowRolling', new Schema({
         id: String,

--- a/roll/z_admin.js
+++ b/roll/z_admin.js
@@ -919,6 +919,11 @@ const rollDiceCommand = async function ({
                         returnDocument: 'after'
                     });
                 } catch (error) {
+                    // Race: another user claimed the same userName between findOne and upsert.
+                    if (error?.code === 11_000 || error?.codeName === 'DuplicateKey') {
+                        rply.text += translate('admin.account_username_duplicated');
+                        return rply;
+                    }
                     console.error('[Admin] Account error:', error);
                     rply.text += JSON.stringify(error);
                     return rply;

--- a/test/z_admin.test.js
+++ b/test/z_admin.test.js
@@ -286,4 +286,21 @@ describe('Admin Module Tests', () => {
     expect(result.type).toBe('text');
     expect(result.text).toBe('重覆用戶名稱');
   });
+
+  test('Test account command maps unique-index race to duplicated message', async () => {
+    schema.accountPW.findOne.mockResolvedValueOnce(null);
+    const duplicateError = Object.assign(new Error('E11000 duplicate key'), {
+      code: 11_000,
+      codeName: 'DuplicateKey',
+    });
+    schema.accountPW.findOneAndUpdate.mockRejectedValueOnce(duplicateError);
+
+    const result = await adminModule.rollDiceCommand({
+      mainMsg: ['.admin', 'account', 'raceuser', 'password123'],
+      userid: 'test_user'
+    });
+
+    expect(result.type).toBe('text');
+    expect(result.text).toBe('重覆用戶名稱');
+  });
 }); 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Closes the M15 account impersonation / race gap from the July 2026 repo review: `accountPW.userName` was only indexed, not unique, so concurrent `.admin account` upserts could create two rows with the same login name and `findOne` could authenticate the wrong document.

## Changes
- `modules/db/schema.js`: `userName` is now `unique: true, sparse: true` (sparse keeps `registerChannel` docs without a login name valid).
- Boot-time `createIndex` (production has `autoIndex` off) with a clear error if duplicate rows block index creation.
- `roll/z_admin.js`: map Mongo `E11000` / `DuplicateKey` to the existing duplicated-username reply instead of dumping the raw error.
- Test for the unique-index race path.

## Deploy note
Before/after deploy, if index creation fails, find and resolve duplicates:

```js
db.accountpws.aggregate([
  { $match: { userName: { $type: 'string' } } },
  { $group: { _id: '$userName', n: { $sum: 1 }, ids: { $push: '$id' } } },
  { $match: { n: { $gt: 1 } } }
])
```

If an old non-unique `userName_1` index blocks recreate:

```js
db.accountpws.dropIndex('userName_1')
// then restart so schema createIndex runs again
```

## Test plan
- [x] `yarn test test/z_admin.test.js --coverage=false`
- [x] ESLint on touched files
- [ ] After merge: confirm `userName_1` is unique+sparse in production Mongo
- [ ] Smoke `.admin account` set + duplicate name rejection
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc0db-58e5-7760-8716-91837de88860?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc0db-58e5-7760-8716-91837de88860&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

