### PR TITLE
Fix schedule [[.ai]] echoing raw prompt on timeout

### DIFF
--- a/modules/chat/getRoll.js
+++ b/modules/chat/getRoll.js
@@ -2,12 +2,19 @@
 
 const parseRouter = require('../roll-worker/parse-router');
 
+/** Long [[.ai]] prompts often exceed the default Worker HTTP timeout during schedule runs. */
+const SCHEDULE_AI_TIMEOUT_MS = Number.parseInt(
+	process.env.SCHEDULE_AI_TIMEOUT_MS || String(5 * 60 * 1000),
+	10
+);
+
 /**
  * Replace [[expression]] segments with dice results via parse router (Worker when enabled).
  * Schedule always allows local fallback so worker outages do not inject system_busy into cron text.
+ * Uses [\s\S] so multi-line [[.ai ...]] prompts are matched (`.` alone stops at newlines).
  */
 async function rollText(text, options = {}) {
-	return replaceAsync(text, /\[\[(.*?)\]\]/ig, (match, expression) =>
+	return replaceAsync(text, /\[\[([\s\S]*?)\]\]/gi, (match, expression) =>
 		rollDiceExpression(match, expression, options)
 	);
 }
@@ -21,18 +28,58 @@ async function replaceAsync(str, regex, asyncFn) {
 	return str.replace(regex, () => data.shift());
 }
 
+function isBotCommandExpression(expression) {
+	return /^\.\S+/i.test(String(expression || '').trim());
+}
+
+function isAiCommandExpression(expression) {
+	// .ai / .aim / .aih / .ait / .aimage / …
+	return /^\.ai/i.test(String(expression || '').trim());
+}
+
+async function systemBusyText(locale) {
+	try {
+		const i18n = require('../i18n/i18n.js');
+		await i18n.init();
+		return i18n.createTranslator(locale || i18n.DEFAULT_LOCALE)('common.errors.system_busy');
+	} catch {
+		return '';
+	}
+}
+
 async function rollDiceExpression(match, expression, options = {}) {
-	const result = await parseRouter.parseInput({
-		inputStr: expression,
-		botname: options.botname || 'Schedule',
-		locale: options.locale || null,
-		groupid: options.groupid || null,
-		userid: options.userid || null,
-		channelid: options.channelid || null,
-		// Schedule [[dice]] substitution must never award channel XP.
-		skipExp: true,
-	}, { allowLocalFallback: true });
-	return (result && result.text) ? result.text : match;
+	const parseOptions = { allowLocalFallback: true };
+	// Long scheduled AI prompts need more than ROLL_WORKER_TIMEOUT_MS (often 120s).
+	if (isAiCommandExpression(expression)
+		&& Number.isFinite(SCHEDULE_AI_TIMEOUT_MS)
+		&& SCHEDULE_AI_TIMEOUT_MS > 0) {
+		parseOptions.timeoutMs = SCHEDULE_AI_TIMEOUT_MS;
+	}
+
+	let result;
+	try {
+		result = await parseRouter.parseInput({
+			inputStr: expression,
+			botname: options.botname || 'Schedule',
+			locale: options.locale || null,
+			groupid: options.groupid || null,
+			userid: options.userid || null,
+			channelid: options.channelid || null,
+			// Schedule [[dice]] substitution must never award channel XP.
+			skipExp: true,
+		}, parseOptions);
+	} catch (error) {
+		console.error('[getRoll] rollDiceExpression failed:', error?.message || error);
+		result = null;
+	}
+
+	if (result && result.text) return result.text;
+
+	// Never echo raw [[.ai long prompt]] (or other .commands) when parse timed out / returned empty.
+	if (isBotCommandExpression(expression)) {
+		return systemBusyText(options.locale);
+	}
+	return match;
 }
 
 module.exports = {

--- a/modules/core-Line.js
+++ b/modules/core-Line.js
@@ -502,7 +502,18 @@ if (agenda && agenda.agenda && lineAgenda) {
 	agenda.agenda.define("scheduleAtMessageLine", async (job) => {
 		//指定時間一次	
 		let data = job.attrs.data;
-		let text = await rollText(data.replyText, { botname: 'Line', groupid: data.groupid });
+		const locale = await i18n.resolveLocale({
+			groupid: data.groupid || '',
+			userid: data.userid || '',
+			botname: 'Line',
+		});
+		let text = await rollText(data.replyText, {
+			botname: 'Line',
+			groupid: data.groupid,
+			userid: data.userid,
+			channelid: data.channelid,
+			locale,
+		});
 		//SendToReply(ctx, text)
 		SendToId(
 			data.groupid, text
@@ -517,7 +528,18 @@ if (agenda && agenda.agenda && lineAgenda) {
 	agenda.agenda.define("scheduleCronMessageLine", async (job) => {
 		//指定時間一次	
 		let data = job.attrs.data;
-		let text = await rollText(data.replyText, { botname: 'Line', groupid: data.groupid });
+		const locale = await i18n.resolveLocale({
+			groupid: data.groupid || '',
+			userid: data.userid || '',
+			botname: 'Line',
+		});
+		let text = await rollText(data.replyText, {
+			botname: 'Line',
+			groupid: data.groupid,
+			userid: data.userid,
+			channelid: data.channelid,
+			locale,
+		});
 		//SendToReply(ctx, text)
 		SendToId(
 			data.groupid, text
@@ -525,9 +547,8 @@ if (agenda && agenda.agenda && lineAgenda) {
 		try {
 			if ((new Date(Date.now()) - data.createAt) >= SIX_MONTH) {
 				await job.remove();
-				const cronLocale = await i18n.resolveLocale({ groupid: data.groupid || '', botname: 'Line' });
 				SendToId(
-					data.groupid, i18n.createTranslator(cronLocale)('platform.schedule.six_month_remove')
+					data.groupid, i18n.createTranslator(locale)('platform.schedule.six_month_remove')
 				)
 			}
 		} catch (error) {

--- a/modules/core-Telegram.js
+++ b/modules/core-Telegram.js
@@ -451,7 +451,18 @@ if (agenda && agenda.agenda) {
     agenda.agenda.define("scheduleAtMessageTelegram", async (job) => {
         //指定時間一次
         let data = job.attrs.data;
-        let text = await rollText(data.replyText, { botname: 'Telegram', groupid: data.groupid });
+        const locale = await i18n.resolveLocale({
+            groupid: data.groupid || '',
+            userid: data.userid || '',
+            botname: 'Telegram',
+        });
+        let text = await rollText(data.replyText, {
+            botname: 'Telegram',
+            groupid: data.groupid,
+            userid: data.userid,
+            channelid: data.channelid,
+            locale,
+        });
         //SendToReply(ctx, text)
         SendToId(
             data.groupid, text
@@ -466,7 +477,18 @@ if (agenda && agenda.agenda) {
     agenda.agenda.define("scheduleCronMessageTelegram", async (job) => {
         //指定時間
         let data = job.attrs.data;
-        let text = await rollText(data.replyText, { botname: 'Telegram', groupid: data.groupid });
+        const locale = await i18n.resolveLocale({
+            groupid: data.groupid || '',
+            userid: data.userid || '',
+            botname: 'Telegram',
+        });
+        let text = await rollText(data.replyText, {
+            botname: 'Telegram',
+            groupid: data.groupid,
+            userid: data.userid,
+            channelid: data.channelid,
+            locale,
+        });
         //SendToReply(ctx, text)
         SendToId(
             data.groupid, text
@@ -474,9 +496,8 @@ if (agenda && agenda.agenda) {
         try {
             if ((new Date(Date.now()) - data.createAt) >= SIX_MONTH) {
                 await job.remove();
-                const cronLocale = await i18n.resolveLocale({ groupid: data.groupid || '', botname: 'Telegram' });
                 SendToId(
-                    data.groupid, i18n.createTranslator(cronLocale)('platform.schedule.six_month_remove')
+                    data.groupid, i18n.createTranslator(locale)('platform.schedule.six_month_remove')
                 )
             }
         } catch (error) {

--- a/modules/core-Whatsapp.js
+++ b/modules/core-Whatsapp.js
@@ -402,8 +402,13 @@ function setupAgenda(client) {
 
 	agenda.agenda.define("scheduleAtMessageWhatsapp", async (job) => {
 		try {
-			const { groupid, replyText } = job.attrs.data;
-			const text = await rollText(replyText, { botname: 'Whatsapp', groupid });
+			const { groupid, replyText, userid } = job.attrs.data;
+			const locale = await i18n.resolveLocale({
+				groupid: groupid || '',
+				userid: userid || '',
+				botname: 'Whatsapp',
+			});
+			const text = await rollText(replyText, { botname: 'Whatsapp', groupid, userid, locale });
 			await SendToId(groupid, { text: text }, client);
 			await job.remove();
 		} catch (error) {
@@ -413,13 +418,17 @@ function setupAgenda(client) {
 
 	agenda.agenda.define("scheduleCronMessageWhatsapp", async (job) => {
 		try {
-			const { groupid, replyText, createAt } = job.attrs.data;
-			const text = await rollText(replyText, { botname: 'Whatsapp', groupid });
+			const { groupid, replyText, createAt, userid } = job.attrs.data;
+			const locale = await i18n.resolveLocale({
+				groupid: groupid || '',
+				userid: userid || '',
+				botname: 'Whatsapp',
+			});
+			const text = await rollText(replyText, { botname: 'Whatsapp', groupid, userid, locale });
 			await SendToId(groupid, { text: text }, client);
 			if ((new Date(Date.now()) - createAt) >= SIX_MONTH) {
 				await job.remove();
-				const cronLocale = await i18n.resolveLocale({ groupid: groupid || '', botname: 'Whatsapp' });
-				await SendToId(groupid, { text: i18n.createTranslator(cronLocale)('platform.schedule.six_month_remove') }, client);
+				await SendToId(groupid, { text: i18n.createTranslator(locale)('platform.schedule.six_month_remove') }, client);
 			}
 		} catch (error) {
 			console.error("Schedule Error:", error);

--- a/modules/discord/bot.js
+++ b/modules/discord/bot.js
@@ -2618,10 +2618,17 @@ function respawnCluster2(meta = {}) {
 		// Specify time once	
 		//if (shardids !== 0) return;
 		let data = job.attrs.data;
+		const locale = await i18n.resolveLocale({
+			groupid: data.groupid || '',
+			userid: data.userid || '',
+			botname: 'Discord',
+		});
 		let text = await rollText(data.replyText, {
 			botname: 'Discord',
 			groupid: data.groupid,
 			channelid: data.channelid,
+			userid: data.userid,
+			locale,
 		});
 		if ((/<@\S+>/g).test(text)) quotes = false;
 		try {
@@ -2649,10 +2656,17 @@ function respawnCluster2(meta = {}) {
 		// Specify time once	
 		//if (shardids !== 0) return;
 		let data = job.attrs.data;
+		const locale = await i18n.resolveLocale({
+			groupid: data.groupid || '',
+			userid: data.userid || '',
+			botname: 'Discord',
+		});
 		let text = await rollText(data.replyText, {
 			botname: 'Discord',
 			groupid: data.groupid,
 			channelid: data.channelid,
+			userid: data.userid,
+			locale,
 		});
 		if ((/<@\S+>/g).test(text)) quotes = false;
 		try {
@@ -2670,8 +2684,7 @@ function respawnCluster2(meta = {}) {
 		try {
 			if ((new Date(Date.now()) - data.createAt) >= SIX_MONTH) {
 				await job.remove();
-				const cronLocale = await i18n.resolveLocale({ groupid: data.groupid || '', botname: 'Discord' });
-				const cronT = i18n.createTranslator(cronLocale);
+				const cronT = i18n.createTranslator(locale);
 				await SendToReplychannel(
 					{ replyText: cronT('discord.schedule.six_month_remove'), channelid: data.channelid, quotes: true, groupid: data.groupid }
 				)

--- a/modules/roll-worker/client.js
+++ b/modules/roll-worker/client.js
@@ -178,11 +178,14 @@ function toSerializableContext(params = {}) {
  * POST /v1/parse against an explicit Worker base URL.
  * @param {string} baseUrl
  * @param {object} params
- * @param {{ trackPrimaryLink?: boolean }} [options]
+ * @param {{ trackPrimaryLink?: boolean, timeoutMs?: number }} [options]
  */
 async function parseWithUrl(baseUrl, params, options = {}) {
 	const trackPrimaryLink = options.trackPrimaryLink !== false;
-	const { token, timeoutMs } = getConfig();
+	const { token, timeoutMs: defaultTimeoutMs } = getConfig();
+	const timeoutMs = (Number.isFinite(options.timeoutMs) && options.timeoutMs > 0)
+		? options.timeoutMs
+		: defaultTimeoutMs;
 	const url = String(baseUrl || '').replace(/\/$/, '');
 	if (!url) {
 		throw new Error('Roll worker URL missing');
@@ -237,18 +240,26 @@ async function parseWithUrl(baseUrl, params, options = {}) {
 	return response.data;
 }
 
-async function parse(params) {
+/**
+ * @param {object} params
+ * @param {{ timeoutMs?: number }} [options]
+ */
+async function parse(params, options = {}) {
 	const { url } = getConfig();
-	return parseWithUrl(url, params, { trackPrimaryLink: true });
+	return parseWithUrl(url, params, { trackPrimaryLink: true, timeoutMs: options.timeoutMs });
 }
 
-/** Hybrid fallback: parse on ROLL_STANDBY_URL (does not affect primary link monitor). */
-async function parseLocal(params) {
+/**
+ * Hybrid fallback: parse on ROLL_STANDBY_URL (does not affect primary link monitor).
+ * @param {object} params
+ * @param {{ timeoutMs?: number }} [options]
+ */
+async function parseLocal(params, options = {}) {
 	const { url } = getLocalConfig();
 	if (!url) {
 		throw new Error('ROLL_STANDBY_URL unset');
 	}
-	return parseWithUrl(url, params, { trackPrimaryLink: false });
+	return parseWithUrl(url, params, { trackPrimaryLink: false, timeoutMs: options.timeoutMs });
 }
 
 /**

--- a/modules/roll-worker/parse-router.js
+++ b/modules/roll-worker/parse-router.js
@@ -293,6 +293,7 @@ function stripWorkerProof(result) {
  * @param {boolean} [options.keepProof=false] - keep `_rollWorker` markers for tests / ops
  * @param {boolean} [options.deferredReplay=false] - drain path; allow local under remote-only
  * @param {object} [options.replyTarget] - defer-queue delivery target (Discord/TG/LINE/WA/WWW)
+ * @param {number} [options.timeoutMs] - optional per-call Worker HTTP timeout override
  */
 async function parseInput(params = {}, options = {}) {
 	// Ensure auto primary/local Workers are up before first route decision.
@@ -309,6 +310,9 @@ async function parseInput(params = {}, options = {}) {
 		: !remoteOnly;
 	const keepProof = options.keepProof === true;
 	const replyTarget = options.replyTarget || null;
+	const parseHttpOptions = (Number.isFinite(options.timeoutMs) && options.timeoutMs > 0)
+		? { timeoutMs: options.timeoutMs }
+		: {};
 
 	const mainMsg = typeof params.inputStr === 'string'
 		? params.inputStr.replaceAll(/^\s/g, '').match(/\S+/ig)
@@ -397,7 +401,7 @@ async function parseInput(params = {}, options = {}) {
 				const httpLocal = await client.parseLocal({
 					...remoteParams,
 					skipExp: skip,
-				});
+				}, parseHttpOptions);
 				if (httpLocal?.needsLocal) {
 					logLocalFallback('localHttpNeedsLocal', {
 						botname: params.botname,
@@ -442,7 +446,7 @@ async function parseInput(params = {}, options = {}) {
 				const httpLocal = await client.parseLocal({
 					...remoteParams,
 					skipExp: false,
-				});
+				}, parseHttpOptions);
 				if (httpLocal?.needsLocal) {
 					const deferred = await tryDeferBusy({
 						reason: 'needsLocal',
@@ -478,7 +482,7 @@ async function parseInput(params = {}, options = {}) {
 	}
 
 	try {
-		const result = await client.parse(remoteParams);
+		const result = await client.parse(remoteParams, parseHttpOptions);
 		if (result?.needsLocal) {
 			if (allowLocalFallback) {
 				logLocalFallback('needsLocal', {

--- a/test/getRoll.test.js
+++ b/test/getRoll.test.js
@@ -4,6 +4,15 @@ jest.mock('../modules/roll-worker/parse-router', () => ({
 	parseInput: jest.fn(),
 }));
 
+jest.mock('../modules/i18n/i18n.js', () => ({
+	DEFAULT_LOCALE: 'zh-tw',
+	init: jest.fn(async () => {}),
+	createTranslator: jest.fn(() => (key) => {
+		if (key === 'common.errors.system_busy') return '系統忙碌中，請稍後再試。';
+		return key;
+	}),
+}));
+
 const parseRouter = require('../modules/roll-worker/parse-router');
 const { rollText } = require('../modules/chat/getRoll');
 
@@ -24,9 +33,28 @@ describe('getRoll.rollText via parseRouter', () => {
 		}), { allowLocalFallback: true });
 	});
 
-	it('keeps original segment when parse returns empty', async () => {
+	it('keeps original segment when dice parse returns empty', async () => {
 		parseRouter.parseInput.mockResolvedValue({ text: '', type: 'text' });
 		const out = await rollText('x [[2d6]] y');
 		expect(out).toBe('x [[2d6]] y');
+	});
+
+	it('matches multi-line [[.ai]] prompts', async () => {
+		parseRouter.parseInput.mockResolvedValue({ text: 'AI reply', type: 'text' });
+		const out = await rollText('prefix [[.ai\nlong prompt\nline2]] suffix', { botname: 'Schedule' });
+		expect(out).toBe('prefix AI reply suffix');
+		expect(parseRouter.parseInput).toHaveBeenCalledWith(
+			expect.objectContaining({ inputStr: '.ai\nlong prompt\nline2' }),
+			expect.objectContaining({ allowLocalFallback: true, timeoutMs: expect.any(Number) })
+		);
+	});
+
+	it('does not echo raw [[.ai]] when parse times out / returns empty', async () => {
+		parseRouter.parseInput.mockResolvedValue({ text: '', type: 'text' });
+		const longPrompt = `.ai ${'x'.repeat(500)}`;
+		const out = await rollText(`[[${longPrompt}]]`, { locale: 'zh-tw' });
+		expect(out).toBe('系統忙碌中，請稍後再試。');
+		expect(out).not.toContain('.ai');
+		expect(out).not.toContain('[[');
 	});
 });


### PR DESCRIPTION
Match multi-line [[ ]] segments, wait longer for scheduled AI, and show system_busy instead of dumping the command. Pass locale/userid from schedule handlers.